### PR TITLE
Fix:link_toでのログアウトを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
-/vendor/bundle
+/vendor
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,6 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
           </a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <%= link_to 'マイページ', user_path(current_user.id), class: 'dropdown-item' %>
-            <%= button_to 'ログアウト', logout_path, class: 'dropdown-item', method: :delete %>
+            <%= link_to 'ログアウト', logout_path, class: 'dropdown-item', method: :delete %>
           </div>
         </li>
       </ul>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,4 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application", preload: true
+pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.6.0/dist/jquery.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,9 @@ Rails.application.routes.draw do
   get 'privacy', to: 'static_pages#privacy'
   
   get 'login', to: 'user_sessions#new'
+  get 'logout', to: 'user_sessions#destroy'
   post 'login', to: 'user_sessions#create'
-  delete 'logout', to: 'user_sessions#destroy'
+  
 
   resources :users, only: %i[new create edit update show ]
   resources :novels do


### PR DESCRIPTION
## 概要

ログアウトのエラーの原因がjqueryが導入されていないことにあると記載があったので、rails7に導入してみたが<%= javascript_importmap_tags %>の記述でname errorが出る。

参考url
https://qiita.com/bbyuue0323/items/453f2aea309931ea8627
https://www.bokukoko.info/entry/2022/02/15/153751

## コメント
サーバーを再起動してみるとmethodがdeleteになっていた。理由は不明。
また、下記に合わせてroutesをdeleteからgetへ変えたところ、ログアウトできるようになった。

https://teratail.com/questions/356143